### PR TITLE
Added support for "serializers" from config in AdapterPluginManager

### DIFF
--- a/docs/book/plugin-manager.md
+++ b/docs/book/plugin-manager.md
@@ -1,0 +1,21 @@
+# Plugin Manager
+
+## AdapterPluginManager
+
+The `AdapterPluginManager` extends the laminas-servicemanager
+`AbstractPluginManager`, and has the following behaviors:
+
+- It will only return `Laminas\Serializer\Adapter\AdapterInterface` instances.
+- It defines short-name aliases for all shipped serializers (the class name minus
+  the namespace), in a variety of casing combinations.
+- All services are shared by default; a new instance will only be created once and shared each time you call `get()`.
+
+### AdapterPluginManagerFactory
+
+`Laminas\Serializer\AdapterPluginManager` is mapped to the factory
+`Laminas\Serializer\AdapterPluginManagerFactory` when wired to the dependency
+injection container.
+
+The factory will look for the `config` service, and use the `serializers`
+configuration key to seed it with additional services. This configuration key
+should map to an array that follows [standard laminas-servicemanager configuration](https://docs.laminas.dev/laminas-servicemanager/configuring-the-service-manager/).

--- a/docs/book/plugin-manager.md
+++ b/docs/book/plugin-manager.md
@@ -17,3 +17,16 @@ injection container.
 The factory will look for the `config` service, and use the `serializers`
 configuration key to seed it with additional services. This configuration key
 should map to an array that follows [standard laminas-servicemanager configuration](https://docs.laminas.dev/laminas-servicemanager/configuring-the-service-manager/).
+
+To add your own serializer you can add the following configuration:
+
+```php
+// config/autoload/serializers.global.php
+return [    
+    'serializers' => [
+        'factories' => [
+            \App\MyCustomSerializer::class => \App\Container\MyCustomSerializerFactory::class,
+        ],
+    ],
+];
+```

--- a/docs/book/plugin-manager.md
+++ b/docs/book/plugin-manager.md
@@ -14,6 +14,8 @@ The `AdapterPluginManager` extends the laminas-servicemanager
 `Laminas\Serializer\AdapterPluginManagerFactory` when wired to the dependency
 injection container.
 
+The factory will be automatically registered when loading/installing the `Laminas\Serializer` module in `laminas-mvc` and/or loading/installing the `ConfigProvider` into a Mezzio application.
+
 The factory will look for the `config` service, and use the `serializers`
 configuration key to seed it with additional services. This configuration key
 should map to an array that follows [standard laminas-servicemanager configuration](https://docs.laminas.dev/laminas-servicemanager/configuring-the-service-manager/).

--- a/docs/book/plugin-manager.md
+++ b/docs/book/plugin-manager.md
@@ -1,7 +1,5 @@
 # Plugin Manager
 
-## AdapterPluginManager
-
 The `AdapterPluginManager` extends the laminas-servicemanager
 `AbstractPluginManager`, and has the following behaviors:
 
@@ -10,7 +8,7 @@ The `AdapterPluginManager` extends the laminas-servicemanager
   the namespace), in a variety of casing combinations.
 - All services are shared by default; a new instance will only be created once and shared each time you call `get()`.
 
-### AdapterPluginManagerFactory
+## Factory
 
 `Laminas\Serializer\AdapterPluginManager` is mapped to the factory
 `Laminas\Serializer\AdapterPluginManagerFactory` when wired to the dependency

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
     - Home: index.md
     - Introduction: intro.md
     - Adapters: adapter.md
+    - Plugin Manager: plugin-manager.md
 site_name: laminas-serializer
 site_description: "Serialize and deserialize PHP structures to a variety of representations"
 repo_url: 'https://github.com/laminas/laminas-serializer'

--- a/src/AdapterPluginManagerFactory.php
+++ b/src/AdapterPluginManagerFactory.php
@@ -9,6 +9,7 @@
 namespace Laminas\Serializer;
 
 use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
@@ -28,7 +29,30 @@ class AdapterPluginManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        return new AdapterPluginManager($container, $options ?: []);
+        $pluginManager = new AdapterPluginManager($container, $options ?: []);
+
+        // If this is in a laminas-mvc application, the ServiceListener will inject
+        // merged configuration during bootstrap.
+        if ($container->has('ServiceListener')) {
+            return $pluginManager;
+        }
+
+        // If we do not have a config service, nothing more to do
+        if (! $container->has('config')) {
+            return $pluginManager;
+        }
+
+        $config = $container->get('config');
+
+        // If we do not have serializers configuration, nothing more to do
+        if (! isset($config['serializers']) || ! is_array($config['serializers'])) {
+            return $pluginManager;
+        }
+
+        // Wire service configuration for serializers
+        (new Config($config['serializers']))->configureServiceManager($pluginManager);
+
+        return $pluginManager;
     }
 
     /**

--- a/test/AdapterPluginManagerFactoryTest.php
+++ b/test/AdapterPluginManagerFactoryTest.php
@@ -72,7 +72,7 @@ class AdapterPluginManagerFactoryTest extends TestCase
         $this->assertSame($serializer, $serializers->get('test'));
     }
 
-    public function testConfiguresSerializerServicesWhenFound(): void
+    public function testConfiguresSerializerServicesWhenFound()
     {
         $serializer = $this->prophesize(AdapterInterface::class)->reveal();
         $config = [
@@ -105,7 +105,7 @@ class AdapterPluginManagerFactoryTest extends TestCase
         $this->assertSame($serializer, $serializers->get('test-too'));
     }
 
-    public function testDoesNotConfigureSerializerServicesWhenServiceListenerPresent(): void
+    public function testDoesNotConfigureSerializerServicesWhenServiceListenerPresent()
     {
         $serializer = $this->prophesize(AdapterInterface::class)->reveal();
         $config = [
@@ -136,7 +136,7 @@ class AdapterPluginManagerFactoryTest extends TestCase
         $this->assertFalse($serializers->has('test-too'));
     }
 
-    public function testDoesNotConfigureSerializerServicesWhenConfigServiceNotPresent(): void
+    public function testDoesNotConfigureSerializerServicesWhenConfigServiceNotPresent()
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
@@ -151,7 +151,7 @@ class AdapterPluginManagerFactoryTest extends TestCase
         $this->assertInstanceOf(AdapterPluginManager::class, $serializers);
     }
 
-    public function testDoesNotConfigureSerializerServicesWhenConfigServiceDoesNotContainSerializersConfig(): void
+    public function testDoesNotConfigureSerializerServicesWhenConfigServiceDoesNotContainSerializersConfig()
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Added support to load the registered Serializers from the `serializers` config key. Currently this is only supported in `Module.php` when using Laminas MVC. 

Changed this to the format as in other components are build such as the `FilterPluginManagerFactory` in `laminas/laminas-log`.

Change is fully backwards compatible and now more in line with the other Laminas components.