### PR TITLE
Remove zend compatibility

### DIFF
--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -11,7 +11,6 @@ namespace Laminas\Serializer;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
-use Zend\Serializer\Adapter as ZendAdapter;
 
 use function gettype;
 use function is_object;
@@ -47,24 +46,6 @@ class AdapterPluginManager extends AbstractPluginManager
         'PythonPickle' => Adapter\PythonPickle::class,
         'wddx'         => Adapter\Wddx::class,
         'Wddx'         => Adapter\Wddx::class,
-
-        // Legacy Zend Framework aliases
-        ZendAdapter\IgBinary::class     => Adapter\IgBinary::class,
-        ZendAdapter\Json::class         => Adapter\Json::class,
-        ZendAdapter\MsgPack::class      => Adapter\MsgPack::class,
-        ZendAdapter\PhpCode::class      => Adapter\PhpCode::class,
-        ZendAdapter\PhpSerialize::class => Adapter\PhpSerialize::class,
-        ZendAdapter\PythonPickle::class => Adapter\PythonPickle::class,
-        ZendAdapter\Wddx::class         => Adapter\Wddx::class,
-
-        // v2 normalized FQCNs
-        'zendserializeradapterigbinary'     => Adapter\IgBinary::class,
-        'zendserializeradapterjson'         => Adapter\Json::class,
-        'zendserializeradaptermsgpack'      => Adapter\MsgPack::class,
-        'zendserializeradapterphpcode'      => Adapter\PhpCode::class,
-        'zendserializeradapterphpserialize' => Adapter\PhpSerialize::class,
-        'zendserializeradapterpythonpickle' => Adapter\PythonPickle::class,
-        'zendserializeradapterwddx'         => Adapter\Wddx::class,
     ];
 
     /** @var array<string, string> */

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -30,8 +30,6 @@ class ConfigProvider
     public function getDependencyConfig()
     {
         return [
-            // Legacy Zend Framework aliases
-            'aliases'   => [],
             'factories' => [
                 'SerializerAdapterManager' => AdapterPluginManagerFactory::class,
             ],


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With one of the 2.x versions, the `zendframework` replacement was already dropped but the code was still available. To avoid unnecessary BC breaks, moving this change to v3.0.0