### PR TITLE
Deprecate `Laminas\Serializer\Serializer`

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace Laminas\Serializer;
 
+use Laminas\Serializer\Adapter\AdapterInterface;
+use Laminas\Serializer\Adapter\PhpSerialize;
+
 class ConfigProvider
 {
     /**
@@ -34,6 +37,7 @@ class ConfigProvider
             'aliases'   => [],
             'factories' => [
                 'SerializerAdapterManager' => AdapterPluginManagerFactory::class,
+                AdapterInterface::class    => new GenericSerializerFactory(PhpSerialize::class),
             ],
         ];
     }

--- a/src/GenericSerializerFactory.php
+++ b/src/GenericSerializerFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Serializer;
+
+use Laminas\Serializer\Adapter\AdapterInterface;
+use Psr\Container\ContainerInterface;
+
+final class GenericSerializerFactory
+{
+    /**
+     * @param class-string<AdapterInterface> $serializerName
+     * @param array<string,mixed>|null       $options
+     */
+    public function __construct(private string $serializerName, private array|null $options = null)
+    {
+    }
+
+    public function __invoke(ContainerInterface $container): AdapterInterface
+    {
+        $plugins = $container->get(AdapterPluginManager::class);
+
+        return $plugins->build($this->serializerName, $this->options);
+    }
+}

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -12,6 +12,9 @@ use Laminas\Serializer\Adapter\AdapterInterface as Adapter;
 use Laminas\ServiceManager\ServiceManager;
 use Traversable;
 
+/**
+ * @deprecated This class will be removed with v3.0.0. Please migrate your code according to the migration guide.
+ */
 // phpcs:ignore
 abstract class Serializer
 {

--- a/test/GenericSerializerFactoryTest.php
+++ b/test/GenericSerializerFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Serializer;
+
+use Laminas\Serializer\Adapter\Json;
+use Laminas\Serializer\Adapter\JsonOptions;
+use Laminas\Serializer\AdapterPluginManager;
+use Laminas\Serializer\GenericSerializerFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class GenericSerializerFactoryTest extends TestCase
+{
+    public function testWillRequestInstanceFromPluginManager(): void
+    {
+        $factory   = new GenericSerializerFactory(Json::class, ['cycle_check' => true]);
+        $container = $this->createMock(ContainerInterface::class);
+        $plugins   = new AdapterPluginManager($container);
+
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with(AdapterPluginManager::class)
+            ->willReturn($plugins);
+
+        $adapter = $factory($container);
+        self::assertInstanceOf(Json::class, $adapter);
+        self::assertTrue($adapter->getOptions()->getCycleCheck());
+        // Verify that default of json options is false so that we do not accidentally test for default `true` value
+        self::assertFalse((new JsonOptions())->getCycleCheck());
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This deprecates the usage of `Laminas\Serializer\Serializer` which will be removed with v3.0.0.
To allow projects to prepare for the migration, this also adds the `GenericSerializerFactory` for forward-compatibility which both provides a default serializer as of v2.16.0 (`PhpSerialize`) and is the successor of `Laminas\Serializer\Serializer` as projects should depend on the default serializer configured in project configurations rather than depending on some whatever default is configured within `Laminas\Serializer\Serializer`.