### PR TITLE
Require stable v4.0 of `laminas-servicemanager`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,12 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "laminas/laminas-json": "^3.1",
-        "laminas/laminas-servicemanager": "~4.0.0-rc2 || ^4.0",
+        "laminas/laminas-servicemanager": "^4.0",
         "laminas/laminas-stdlib": "^3.2"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
+        "laminas/laminas-servicemanager": "^4.0.0-rc2",
         "lctrs/psalm-psr-container-plugin": "^1.9",
         "phpunit/phpunit": "^10.2.6",
         "psalm/plugin-phpunit": "^0.18.4",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "laminas/laminas-json": "^3.1",
-        "laminas/laminas-servicemanager": "^4.0.0-rc2",
+        "laminas/laminas-servicemanager": "~4.0.0-rc2 || ^4.0",
         "laminas/laminas-stdlib": "^3.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0c98da2a7e48a6c00147434f3a9a581",
+    "content-hash": "e44f2010c8cebe09e0d26c43cb1e2c34",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -4300,5 +4300,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e44f2010c8cebe09e0d26c43cb1e2c34",
+    "content-hash": "46b3e58f1bcbbd1c8a822660900b1b99",
     "packages": [
         {
             "name": "brick/varexporter",


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

AFAIR, having stuff like `-dev` or `-rc` within the constraint allows composer to always install non-stable dependencies. 
Allowing any RC candidate starting with RC2 of `laminas-servicemanager` v4 and the whole `v4` range should fix this.