### PR TITLE
Deprecate `Json` adapter, as laminas-json is abandoned

### DIFF
--- a/src/Adapter/Json.php
+++ b/src/Adapter/Json.php
@@ -13,6 +13,9 @@ use Laminas\Json\Json as LaminasJson;
 use Laminas\Serializer\Exception;
 use Traversable;
 
+/**
+ * @deprecated This serializer will get removed in v4.0.0. Use PhpSerialize as a replacement.
+ */
 class Json extends AbstractAdapter
 {
     /** @var JsonOptions */

--- a/src/Adapter/JsonOptions.php
+++ b/src/Adapter/JsonOptions.php
@@ -11,6 +11,9 @@ namespace Laminas\Serializer\Adapter;
 use Laminas\Json\Json as LaminasJson;
 use Laminas\Serializer\Exception;
 
+/**
+ * @deprecated This serializer will get removed in v4.0.0. Use PhpSerialize as a replacement.
+ */
 class JsonOptions extends AdapterOptions
 {
     /** @var bool */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | not yet, but in 4.0
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Related to #72. Marks the `Json` adapter, which uses laminas-json, as deprecated. 

Should go into `2.18.x` and `3.2.x` with the relevant classes to be dropped in 4.0.

What, to me, seems to be a bit of a downside is that we cannot make a new laminas-serializer release dropping laminas-json for laminas-servicemanager v3. This is because laminas-serializer v3 with support for laminas-servicemanger v4 has already been released, so there is no version number anymore to make BC breaks in the laminas-serializer v2 series. This is not yet a real issue, but it would become an issue if PHP 8.5 was released before the whole Laminas ecosystems is on servicemanger v4, because then we would need a new release of the abandoned laminas-json, to keep our applications running.