### PR TITLE
Removes laminas-json as dependency and uses PHP’s native json functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-        "laminas/laminas-json": "^3.1",
         "laminas/laminas-servicemanager": "^4.5",
         "laminas/laminas-stdlib": "^3.19"
     },
@@ -59,6 +58,9 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
+        "static-analysis:b": "psalm --update-baseline",
+        "static-analysis:clear": "psalm --clear-cache",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7c5042803c8e832b4c19a920ca7a007",
+    "content-hash": "1e6565336d19100fe108fd1aa0ec32d1",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -54,68 +54,6 @@
                 }
             ],
             "time": "2025-02-20T17:42:39+00:00"
-        },
-        {
-            "name": "laminas/laminas-json",
-            "version": "3.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-json.git",
-                "reference": "5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0",
-                "reference": "5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1.0"
-            },
-            "conflict": {
-                "zendframework/zend-json": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-stdlib": "^2.7.7 || ^3.19",
-                "phpunit/phpunit": "^9.5.25"
-            },
-            "suggest": {
-                "laminas/laminas-json-server": "For implementing JSON-RPC servers",
-                "laminas/laminas-xml2json": "For converting XML documents to JSON"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Json\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "json",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-json/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-json/issues",
-                "rss": "https://github.com/laminas/laminas-json/releases.atom",
-                "source": "https://github.com/laminas/laminas-json"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2026-01-23T11:10:11+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -5664,5 +5602,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/book/v4/adapter.md
+++ b/docs/book/v4/adapter.md
@@ -1,0 +1,69 @@
+# Adapters
+
+laminas-serializer adapters handle serialization to and deserialization from
+specific representations.
+
+Each adapter has its own strengths. In some cases, not every PHP datatype (e.g.,
+objects) can be converted to a string representation. In most such cases, the
+type will be converted to a similar type that is serializable.
+
+As an example, PHP objects will often be cast to arrays. If this fails, a
+`Laminas\Serializer\Exception\ExceptionInterface` will be thrown.
+
+## The PhpSerialize Adapter
+
+The `Laminas\Serializer\Adapter\PhpSerialize` adapter uses the built-in
+[serialize()](https://php.net/serialize)/[unserialize()](https://php.net/unserialize)
+functions, and is a good default adapter choice.
+
+Available options include:
+
+| Option                      | Data Type         | Default Value | Description                                                                                                                                        |
+|-----------------------------|-------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| unserialize_class_whitelist | `array` or `bool` | `true`        | The allowed classes for unserialize(), see [unserialize()](https://php.net/unserialize) for more information. Only available on PHP 7.0 or higher. |
+
+## The IgBinary Adapter
+
+[Igbinary](https://pecl.php.net/package/igbinary) was originally released by
+Sulake Dynamoid Oy and since 2011-03-14 moved to [PECL](https://pecl.php.net) and
+maintained by Pierre Joye. It's a drop-in replacement for the standard PHP
+serializer. Instead of using a costly textual representation, igbinary stores
+PHP data structures in a compact binary form. Savings are significant when using
+memcached or similar memory based storages for serialized data.
+
+You need the igbinary PHP extension installed on your system in order to use
+this adapter.
+
+There are no configurable options for this adapter.
+
+## The Json Adapter
+
+The [JSON](https://wikipedia.org/wiki/JavaScript_Object_Notation) provides serialization
+and deserialization using PHP’s native JSON functions:
+[json_encode()](https://www.php.net/manual/en/function.json-encode.php)
+and [json_decode()](https://www.php.net/manual/en/function.json-decode.php)
+
+During serialization, data is converted to a JSON string using `json_encode()`.
+During deserialization, the JSON string is converted back to PHP data structures using `json_decode()`.
+
+Available options include:
+
+| Option        | Data Type | Default Value |
+|---------------|-----------|---------------|
+| `assoc_array` | `boolean` | `true`        |
+
+## The PhpCode Adapter
+
+The `Laminas\Serializer\Adapter\PhpCode` adapter generates a parsable PHP code
+representation using [var_export()](https://php.net/var_export). To restore,
+the data will be executed using [eval](https://php.net/eval).
+
+There are no configuration options for this adapter.
+
+WARNING: **Unserializing Objects**
+Objects will be serialized using the [__set_state](https://php.net/language.oop5.magic#language.oop5.magic.set-state) magic method.
+If the class doesn't implement this method, a fatal error will occur during execution.
+
+WARNING: **Uses `eval()`**
+The `PhpCode` adapter utilizes `eval()` to unserialize. This introduces both a performance and potential security issue as a new process will be executed.
+Typically, you should use the `PhpSerialize` adapter unless you require human-readability of the serialized data.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.14.3@d0b040a91f280f071c1abcb1b77ce3822058725a">
+<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
   <file src="src/Adapter/Json.php">
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$options]]></code>
@@ -7,12 +7,6 @@
     <NonInvariantDocblockPropertyType>
       <code><![CDATA[$options]]></code>
     </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="src/Adapter/JsonOptions.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setCycleCheck]]></code>
-      <code><![CDATA[setEnableJsonExprFinder]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="src/Adapter/PhpSerialize.php">
     <MoreSpecificImplementedParamType>

--- a/src/Adapter/Json.php
+++ b/src/Adapter/Json.php
@@ -8,14 +8,12 @@ use InvalidArgumentException;
 use JsonException;
 use Laminas\Serializer\Exception;
 
-use function in_array;
-use function is_array;
-use function is_int;
-use function is_object;
 use function json_decode;
 use function json_encode;
 
 use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
 
 final class Json extends AbstractAdapter
 {
@@ -56,15 +54,8 @@ final class Json extends AbstractAdapter
      */
     public function serialize(mixed $value): string
     {
-        $options    = $this->getOptions();
-        $cycleCheck = $options->getCycleCheck();
-        $opts       = [
-            'enableJsonExprFinder' => $options->getEnableJsonExprFinder(),
-            'objectDecodeType'     => $options->isAssocArray(),
-        ];
-
         try {
-            return $this->encode($value, $cycleCheck, $opts);
+            return $this->encode($value);
         } catch (InvalidArgumentException $e) {
             throw new Exception\InvalidArgumentException('Serialization failed: ' . $e->getMessage(), 0, $e);
         } catch (JsonException $e) {
@@ -89,37 +80,12 @@ final class Json extends AbstractAdapter
         return $ret;
     }
 
-    /**
-     * @param mixed[] $options
-     */
-    private function encode(mixed $value, bool $cycleCheck, array $options): string
+    private function encode(mixed $value): string
     {
-        if ($cycleCheck) {
-            $seen         = [];
-            $detectCycles = function (mixed &$val) use (&$seen, &$detectCycles): void {
-                if (is_array($val) || is_object($val)) {
-                    if (in_array($val, $seen, true)) {
-                        throw new InvalidArgumentException("Cycle detected in value to be JSON encoded");
-                    }
-                    $seen[] = $val;
-                    foreach ($val as &$item) {
-                        $detectCycles($item);
-                    }
-                }
-            };
-            $detectCycles($value);
-        }
-
-        $jsonOptions = isset($options['json_encode_options']) && is_int($options['json_encode_options'])
-            ? $options['json_encode_options']
-            : 0;
-
-        $encoded = json_encode($value, $jsonOptions | JSON_THROW_ON_ERROR);
-        if ($encoded === false) {
-            throw new JsonException('Syntax error');
-        }
-
-        return $encoded;
+        return json_encode(
+            $value,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        );
     }
 
     private function decode(string $value, bool $assoc): mixed
@@ -127,7 +93,7 @@ final class Json extends AbstractAdapter
         return json_decode(
             $value,
             $assoc,
-            512, // depth
+            512,
             JSON_THROW_ON_ERROR
         );
     }

--- a/src/Adapter/Json.php
+++ b/src/Adapter/Json.php
@@ -5,8 +5,17 @@ declare(strict_types=1);
 namespace Laminas\Serializer\Adapter;
 
 use InvalidArgumentException;
-use Laminas\Json\Json as LaminasJson;
+use JsonException;
 use Laminas\Serializer\Exception;
+
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_object;
+use function json_decode;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
 
 final class Json extends AbstractAdapter
 {
@@ -51,14 +60,14 @@ final class Json extends AbstractAdapter
         $cycleCheck = $options->getCycleCheck();
         $opts       = [
             'enableJsonExprFinder' => $options->getEnableJsonExprFinder(),
-            'objectDecodeType'     => $options->getObjectDecodeType(),
+            'objectDecodeType'     => $options->isAssocArray(),
         ];
 
         try {
-            return LaminasJson::encode($value, $cycleCheck, $opts);
+            return $this->encode($value, $cycleCheck, $opts);
         } catch (InvalidArgumentException $e) {
             throw new Exception\InvalidArgumentException('Serialization failed: ' . $e->getMessage(), 0, $e);
-        } catch (\Exception $e) {
+        } catch (JsonException $e) {
             throw new Exception\RuntimeException('Serialization failed: ' . $e->getMessage(), 0, $e);
         }
     }
@@ -72,13 +81,54 @@ final class Json extends AbstractAdapter
     public function unserialize(string $serialized): mixed
     {
         try {
-            $ret = LaminasJson::decode($serialized, $this->getOptions()->getObjectDecodeType());
-        } catch (InvalidArgumentException $e) {
-            throw new Exception\InvalidArgumentException('Unserialization failed: ' . $e->getMessage(), 0, $e);
-        } catch (\Exception $e) {
+            $ret = $this->decode($serialized, $this->getOptions()->isAssocArray());
+        } catch (JsonException $e) {
             throw new Exception\RuntimeException('Unserialization failed: ' . $e->getMessage(), 0, $e);
         }
 
         return $ret;
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    private function encode(mixed $value, bool $cycleCheck, array $options): string
+    {
+        if ($cycleCheck) {
+            $seen         = [];
+            $detectCycles = function (mixed &$val) use (&$seen, &$detectCycles): void {
+                if (is_array($val) || is_object($val)) {
+                    if (in_array($val, $seen, true)) {
+                        throw new InvalidArgumentException("Cycle detected in value to be JSON encoded");
+                    }
+                    $seen[] = $val;
+                    foreach ($val as &$item) {
+                        $detectCycles($item);
+                    }
+                }
+            };
+            $detectCycles($value);
+        }
+
+        $jsonOptions = isset($options['json_encode_options']) && is_int($options['json_encode_options'])
+            ? $options['json_encode_options']
+            : 0;
+
+        $encoded = json_encode($value, $jsonOptions | JSON_THROW_ON_ERROR);
+        if ($encoded === false) {
+            throw new JsonException('Syntax error');
+        }
+
+        return $encoded;
+    }
+
+    private function decode(string $value, bool $assoc): mixed
+    {
+        return json_decode(
+            $value,
+            $assoc,
+            512, // depth
+            JSON_THROW_ON_ERROR
+        );
     }
 }

--- a/src/Adapter/JsonOptions.php
+++ b/src/Adapter/JsonOptions.php
@@ -4,38 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Serializer\Adapter;
 
-use Laminas\Serializer\Exception;
-
 final class JsonOptions extends AdapterOptions
 {
-    protected bool $cycleCheck = false;
+    private bool $assocArray = true;
 
-    protected bool $enableJsonExprFinder = false;
-    private bool $assocArray             = true;
-
-    public function setCycleCheck(bool $flag): void
-    {
-        $this->cycleCheck = $flag;
-    }
-
-    public function getCycleCheck(): bool
-    {
-        return $this->cycleCheck;
-    }
-
-    public function setEnableJsonExprFinder(bool $flag): void
-    {
-        $this->enableJsonExprFinder = $flag;
-    }
-
-    public function getEnableJsonExprFinder(): bool
-    {
-        return $this->enableJsonExprFinder;
-    }
-
-    /**
-     * @throws Exception\InvalidArgumentException
-     */
     public function setAssocArray(bool $assocArray): void
     {
         $this->assocArray = $assocArray;

--- a/src/Adapter/JsonOptions.php
+++ b/src/Adapter/JsonOptions.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Serializer\Adapter;
 
-use Laminas\Json\Json as LaminasJson;
 use Laminas\Serializer\Exception;
 
 final class JsonOptions extends AdapterOptions
@@ -12,9 +11,7 @@ final class JsonOptions extends AdapterOptions
     protected bool $cycleCheck = false;
 
     protected bool $enableJsonExprFinder = false;
-
-    /** @var LaminasJson::TYPE_* */
-    protected int $objectDecodeType = LaminasJson::TYPE_ARRAY;
+    private bool $assocArray             = true;
 
     public function setCycleCheck(bool $flag): void
     {
@@ -37,30 +34,15 @@ final class JsonOptions extends AdapterOptions
     }
 
     /**
-     * @param LaminasJson::TYPE_* $type
      * @throws Exception\InvalidArgumentException
      */
-    public function setObjectDecodeType(int $type): void
+    public function setAssocArray(bool $assocArray): void
     {
-        /**
-         * @psalm-suppress DocblockTypeContradiction Due to the way how the options for plugins work, i.e. using
-         *                                        {@see AbstractOptions::setFromArray()}, having an additional check
-         *                                        here can provide more detailed errors.
-         */
-        if ($type !== LaminasJson::TYPE_ARRAY && $type !== LaminasJson::TYPE_OBJECT) {
-            throw new Exception\InvalidArgumentException(
-                'Unknown decode type: ' . $type
-            );
-        }
-
-        $this->objectDecodeType = $type;
+        $this->assocArray = $assocArray;
     }
 
-    /**
-     * @return LaminasJson::TYPE_*
-     */
-    public function getObjectDecodeType(): int
+    public function isAssocArray(): bool
     {
-        return $this->objectDecodeType;
+        return $this->assocArray;
     }
 }

--- a/test/Adapter/JsonTest.php
+++ b/test/Adapter/JsonTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Serializer\Adapter;
 
-use Laminas\Json\Json as LaminasJson;
 use Laminas\Serializer\Adapter\Json;
 use Laminas\Serializer\Adapter\JsonOptions;
 use Laminas\Serializer\Exception\RuntimeException;
@@ -28,13 +27,13 @@ final class JsonTest extends TestCase
         $options = new JsonOptions([
             'cycle_check'             => true,
             'enable_json_expr_finder' => true,
-            'object_decode_type'      => 1,
+            'assoc_array'             => true,
         ]);
         $adapter->setOptions($options);
 
         self::assertEquals(true, $adapter->getOptions()->getCycleCheck());
         self::assertEquals(true, $adapter->getOptions()->getEnableJsonExprFinder());
-        self::assertEquals(1, $adapter->getOptions()->getObjectDecodeType());
+        self::assertTrue($adapter->getOptions()->isAssocArray());
     }
 
     public function testSerializeString(): void
@@ -134,7 +133,7 @@ final class JsonTest extends TestCase
         $expected       = new stdClass();
         $expected->test = 'test';
 
-        $this->adapter->getOptions()->setObjectDecodeType(LaminasJson::TYPE_OBJECT);
+        $this->adapter->getOptions()->setAssocArray(false);
 
         $data = $this->adapter->unserialize($value);
         self::assertEquals($expected, $data);
@@ -144,7 +143,7 @@ final class JsonTest extends TestCase
     {
         $value = 'not a serialized string';
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unserialization failed: Decoding failed: Syntax error');
+        $this->expectExceptionMessage('Unserialization failed: Syntax error');
         $this->adapter->unserialize($value);
     }
 }

--- a/test/Adapter/JsonTest.php
+++ b/test/Adapter/JsonTest.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace LaminasTest\Serializer\Adapter;
 
+use ArrayIterator;
+use JsonSerializable;
 use Laminas\Serializer\Adapter\Json;
-use Laminas\Serializer\Adapter\JsonOptions;
 use Laminas\Serializer\Exception\RuntimeException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+
+use function json_encode;
+
+use const JSON_UNESCAPED_UNICODE;
 
 #[CoversClass(Json::class)]
 final class JsonTest extends TestCase
@@ -19,21 +24,6 @@ final class JsonTest extends TestCase
     protected function setUp(): void
     {
         $this->adapter = new Json();
-    }
-
-    public function testAdapterAcceptsOptions(): void
-    {
-        $adapter = new Json();
-        $options = new JsonOptions([
-            'cycle_check'             => true,
-            'enable_json_expr_finder' => true,
-            'assoc_array'             => true,
-        ]);
-        $adapter->setOptions($options);
-
-        self::assertEquals(true, $adapter->getOptions()->getCycleCheck());
-        self::assertEquals(true, $adapter->getOptions()->getEnableJsonExprFinder());
-        self::assertTrue($adapter->getOptions()->isAssocArray());
     }
 
     public function testSerializeString(): void
@@ -63,10 +53,37 @@ final class JsonTest extends TestCase
         self::assertEquals($expected, $data);
     }
 
-    public function testSerializeNumeric(): void
+    public function testSerializeInteger(): void
     {
         $value    = 100;
         $expected = '100';
+
+        $data = $this->adapter->serialize($value);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testSerializeFloat(): void
+    {
+        $value    = 1.23;
+        $expected = '1.23';
+
+        $data = $this->adapter->serialize($value);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testSerializeArray(): void
+    {
+        $value    = [1, 2, 3];
+        $expected = '[1,2,3]';
+
+        $data = $this->adapter->serialize($value);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testSerializeAssocArray(): void
+    {
+        $value    = ['foo' => 'bar', 'baz' => 42];
+        $expected = '{"foo":"bar","baz":42}';
 
         $data = $this->adapter->serialize($value);
         self::assertEquals($expected, $data);
@@ -82,68 +99,262 @@ final class JsonTest extends TestCase
         self::assertEquals($expected, $data);
     }
 
-    public function testUnserializeString(): void
+    public function testSerializeUnicode(): void
     {
-        $value    = '"test"';
+        $value    = 'žluťoučký kůň';
+        $expected = '"žluťoučký kůň"';
+
+        $data = $this->adapter->serialize($value);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testSerializeSpecialChars(): void
+    {
+        $value    = "line\nbreak\tand\"quote\"";
+        $expected = '"line\nbreak\tand\"quote\""';
+
+        $data = $this->adapter->serialize($value);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testSerializeWithCycleCheckFalseThrowsNativeExceptionOnCyclicArray(): void
+    {
+        $a         = [];
+        $a['self'] = &$a;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Serialization failed: Recursion detected');
+        $this->adapter->serialize($a);
+    }
+
+    public function testSerializeWithCycleCheckTrueThrowsOnCyclicArray(): void
+    {
+        $a         = [];
+        $a['self'] = &$a;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Serialization failed: Recursion detected');
+        $this->adapter->serialize($a);
+    }
+
+    public function testSerializeWithCycleCheckTrueThrowsOnCyclicObject(): void
+    {
+        $obj       = new stdClass();
+        $obj->self = $obj;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Serialization failed: Recursion detected');
+        $this->adapter->serialize($obj);
+    }
+
+    public function testSerializeWithCycleCheckTrueDoesNotThrowOnNonCyclicValue(): void
+    {
+        $value    = ['foo' => 'bar', 'nested' => ['a', 'b']];
+        $expected = '{"foo":"bar","nested":["a","b"]}';
+
+        $data = $this->adapter->serialize($value);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testSerializeObjectWithJsonSerializable(): void
+    {
+        $obj      = new class implements JsonSerializable {
+            public function jsonSerialize(): array
+            {
+                return ['foo' => 'bar'];
+            }
+        };
+        $expected = '{"foo":"bar"}';
+
+        $data = $this->adapter->serialize($obj);
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testSerializeArrayIterator(): void
+    {
+        $iterator = new ArrayIterator(['foo' => 'bar', 'baz' => 5]);
+        $expected = '{"foo":"bar","baz":5}';
+
+        $data = $this->adapter->serialize($iterator);
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testSerializeNestedArrayOfObjects(): void
+    {
+        $obj1      = new stdClass();
+        $obj1->id  = 1;
+        $obj2      = new stdClass();
+        $obj2->foo = 2;
+        $value     = [$obj1, $obj2];
+        $expected  = '[{"id":1},{"foo":2}]';
+
+        $data = $this->adapter->serialize($value);
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testSerializeObjectOfArrays(): void
+    {
+        $value    = [
+            'codeDbVar' => ['age' => ['int', 5], 'prenom' => ['varchar', 50]],
+            234         => [22, 'jb'],
+            346         => [64, 'francois'],
+            21          => [12, 'paul'],
+        ];
+        $expected = json_encode($value, JSON_UNESCAPED_UNICODE);
+
+        $data = $this->adapter->serialize($value);
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testDeserializeString(): void
+    {
+        $json     = '"test"';
         $expected = 'test';
 
-        $data = $this->adapter->unserialize($value);
+        $data = $this->adapter->unserialize($json);
         self::assertEquals($expected, $data);
     }
 
-    public function testUnserializeFalse(): void
+    public function testDeserializeFalse(): void
     {
-        $value    = 'false';
+        $json     = 'false';
         $expected = false;
 
-        $data = $this->adapter->unserialize($value);
+        $data = $this->adapter->unserialize($json);
         self::assertEquals($expected, $data);
     }
 
-    public function testUnserializeNull(): void
+    public function testDeserializeNull(): void
     {
-        $value    = 'null';
+        $json     = 'null';
         $expected = null;
 
-        $data = $this->adapter->unserialize($value);
+        $data = $this->adapter->unserialize($json);
         self::assertEquals($expected, $data);
     }
 
-    public function testUnserializeNumeric(): void
+    public function testDeserializeInteger(): void
     {
-        $value    = '100';
+        $json     = '100';
         $expected = 100;
 
-        $data = $this->adapter->unserialize($value);
+        $data = $this->adapter->unserialize($json);
         self::assertEquals($expected, $data);
     }
 
-    public function testUnserializeAsArray(): void
+    public function testDeserializeFloat(): void
     {
-        $value    = '{"test":"test"}';
-        $expected = ['test' => 'test'];
+        $json     = '1.23';
+        $expected = 1.23;
 
-        $data = $this->adapter->unserialize($value);
+        $data = $this->adapter->unserialize($json);
         self::assertEquals($expected, $data);
     }
 
-    public function testUnserializeAsObject(): void
+    public function testDeserializeArray(): void
     {
-        $value          = '{"test":"test"}';
-        $expected       = new stdClass();
-        $expected->test = 'test';
+        $json     = '[1,2,3]';
+        $expected = [1, 2, 3];
 
+        $data = $this->adapter->unserialize($json);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testDeserializeAssocArray(): void
+    {
+        $json     = '{"foo":"bar","baz":42}';
+        $expected = ['foo' => 'bar', 'baz' => 42];
+
+        $data = $this->adapter->unserialize($json);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testDeserializeWithAssocArrayTrueReturnsArray(): void
+    {
+        $this->adapter->getOptions()->setAssocArray(true);
+        $json = '{"foo":"bar","baz":42}';
+
+        $data = $this->adapter->unserialize($json);
+        $this->assertIsArray($data);
+        $this->assertEquals(['foo' => 'bar', 'baz' => 42], $data);
+    }
+
+    public function testDeserializeWithAssocArrayFalseReturnsObject(): void
+    {
         $this->adapter->getOptions()->setAssocArray(false);
+        $json          = '{"foo":"bar","baz":42}';
+        $expected      = new stdClass();
+        $expected->foo = 'bar';
+        $expected->baz = 42;
 
-        $data = $this->adapter->unserialize($value);
+        $data = $this->adapter->unserialize($json);
+        $this->assertIsObject($data);
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testDeserializeWithAssocArrayTrueReturnsArrayForNestedObjects(): void
+    {
+        $this->adapter->getOptions()->setAssocArray(true);
+        $json     = '{"outer":{"inner":"value"}}';
+        $expected = ['outer' => ['inner' => 'value']];
+
+        $data = $this->adapter->unserialize($json);
+        $this->assertIsArray($data);
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testDeserializeWithAssocArrayFalseReturnsObjectForNestedObjects(): void
+    {
+        $this->adapter->getOptions()->setAssocArray(false);
+        $json = '{"outer":{"inner":"value"}}';
+
+        $data = $this->adapter->unserialize($json);
+        $this->assertIsObject($data);
+        $this->assertIsObject($data->outer);
+        $this->assertEquals('value', $data->outer->inner);
+    }
+
+    public function testDeserializeUnicode(): void
+    {
+        $json     = '"žluťoučký kůň"';
+        $expected = 'žluťoučký kůň';
+
+        $data = $this->adapter->unserialize($json);
         self::assertEquals($expected, $data);
     }
 
-    public function testUnserialzeInvalid(): void
+    public function testDeserializeSpecialChars(): void
     {
-        $value = 'not a serialized string';
+        $json     = '"line\nbreak\tand\"quote\""';
+        $expected = "line\nbreak\tand\"quote\"";
+
+        $data = $this->adapter->unserialize($json);
+        self::assertEquals($expected, $data);
+    }
+
+    public function testDeserializeEmptyKey(): void
+    {
+        $json = '{"":"test"}';
+
+        $data = $this->adapter->unserialize($json);
+        $this->assertIsArray($data);
+        $this->assertEquals(['' => 'test'], $data);
+    }
+
+    public function testDeserializeThrowsOnInvalidJson(): void
+    {
+        $json = '{invalid json';
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unserialization failed: Syntax error');
-        $this->adapter->unserialize($value);
+        $this->adapter->unserialize($json);
+    }
+
+    public function testDeserializeThrowsOnOctal(): void
+    {
+        $json = '010';
+
+        $this->expectException(RuntimeException::class);
+        $this->adapter->unserialize($json);
     }
 }

--- a/test/GenericSerializerFactoryTest.php
+++ b/test/GenericSerializerFactoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\Serializer;
 
 use Laminas\Serializer\Adapter\Json;
-use Laminas\Serializer\Adapter\JsonOptions;
 use Laminas\Serializer\AdapterPluginManager;
 use Laminas\Serializer\GenericSerializerFactory;
 use PHPUnit\Framework\TestCase;
@@ -15,7 +14,7 @@ final class GenericSerializerFactoryTest extends TestCase
 {
     public function testWillRequestInstanceFromPluginManager(): void
     {
-        $factory   = new GenericSerializerFactory(Json::class, ['cycle_check' => true]);
+        $factory   = new GenericSerializerFactory(Json::class, []);
         $container = $this->createMock(ContainerInterface::class);
         $plugins   = new AdapterPluginManager($container);
 
@@ -27,8 +26,5 @@ final class GenericSerializerFactoryTest extends TestCase
 
         $adapter = $factory($container);
         self::assertInstanceOf(Json::class, $adapter);
-        self::assertTrue($adapter->getOptions()->getCycleCheck());
-        // Verify that default of json options is false so that we do not accidentally test for default `true` value
-        self::assertFalse((new JsonOptions())->getCycleCheck());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This change removes all usage of `Laminas\Json` in favor of PHP’s native `json_encode()` and `json_decode()` functions.

**Reason for change:**
- `laminas/laminas-json` is abandoned and no longer maintained.

**Changes made:**
- Replaced `LaminasJson::encode()` calls with `json_encode()` using `JSON_THROW_ON_ERROR`.
- Replaced `LaminasJson::decode()` calls with `json_decode()` and `$associative` mapping from the configured object decode type.
- Preserved existing cycle check logic and exception wrapping for backward-compatible error handling.

**Impact:**
- Removes dependency on abandoned `laminas/laminas-json` package.
- Potentially changes exception types internally (now using `JsonException` from PHP core), but they are wrapped to maintain public API compatibility.
- This is a BC break
