### PR TITLE
Rename PHP Serialize options to use inclusive language

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: clover.xml
-json_path: coveralls-upload.json

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -3,6 +3,7 @@
         "igbinary"
     ],
     "ignore_php_platform_requirements": {
-        "8.4": true
-    }
+        "8.4": false
+    },
+    "backwardCompatibilityCheck": true
 }

--- a/docs/book/v3/adapter.md
+++ b/docs/book/v3/adapter.md
@@ -18,9 +18,9 @@ functions, and is a good default adapter choice.
 
 Available options include:
 
-| Option                      | Data Type         | Default Value | Description                                                                                                                                        |
-|-----------------------------|-------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| unserialize_class_whitelist | `array` or `bool` | `true`        | The allowed classes for unserialize(), see [unserialize()](https://php.net/unserialize) for more information. Only available on PHP 7.0 or higher. |
+| Option          | Data Type         | Default Value | Description                                                                                                   |
+|-----------------|-------------------|---------------|---------------------------------------------------------------------------------------------------------------|
+| allowed_classes | `array` or `bool` | `true`        | The allowed classes for unserialize(), see [unserialize()](https://php.net/unserialize) for more information. |
 
 ## The IgBinary Adapter
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -25,20 +25,6 @@
       <code><![CDATA[setEnableJsonExprFinder]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="test/Adapter/JsonTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getCycleCheck]]></code>
-      <code><![CDATA[getEnableJsonExprFinder]]></code>
-      <code><![CDATA[getObjectDecodeType]]></code>
-      <code><![CDATA[setObjectDecodeType]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="test/GenericSerializerFactoryTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getCycleCheck]]></code>
-      <code><![CDATA[getCycleCheck]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="src/Adapter/PhpSerialize.php">
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$options]]></code>
@@ -53,22 +39,41 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/AdapterPluginManagerFactory.php">
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options ?? []]]></code>
-    </MixedArgumentTypeCoercion>
     <MixedArgument>
       <code><![CDATA[$config['serializers']]]></code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$options ?? []]]></code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Module.php">
-    <UnusedParam>
-      <code><![CDATA[$moduleManager]]></code>
-    </UnusedParam>
     <UndefinedDocblockClass>
       <code><![CDATA[ModuleManager]]></code>
     </UndefinedDocblockClass>
     <UnusedClass>
       <code><![CDATA[Module]]></code>
     </UnusedClass>
+    <UnusedParam>
+      <code><![CDATA[$moduleManager]]></code>
+    </UnusedParam>
+  </file>
+  <file src="test/Adapter/JsonTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getCycleCheck]]></code>
+      <code><![CDATA[getEnableJsonExprFinder]]></code>
+      <code><![CDATA[getObjectDecodeType]]></code>
+      <code><![CDATA[setObjectDecodeType]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="test/Adapter/PhpSerializeOptionsTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUnserializeClassWhitelist]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="test/GenericSerializerFactoryTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getCycleCheck]]></code>
+      <code><![CDATA[getCycleCheck]]></code>
+    </DeprecatedMethod>
   </file>
 </files>

--- a/src/Adapter/PhpSerialize.php
+++ b/src/Adapter/PhpSerialize.php
@@ -110,7 +110,7 @@ final class PhpSerialize extends AbstractAdapter
 
         ErrorHandler::start($errorLevel);
         // The second parameter to unserialize() is only available on PHP 7.0 or higher
-        $ret = unserialize($serialized, ['allowed_classes' => $this->getOptions()->getUnserializeClassWhitelist()]);
+        $ret = unserialize($serialized, ['allowed_classes' => $this->getOptions()->getAllowedClasses()]);
         $err = ErrorHandler::stop();
 
         if ($ret === false) {

--- a/src/Adapter/PhpSerializeOptions.php
+++ b/src/Adapter/PhpSerializeOptions.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Serializer\Adapter;
 
+use Laminas\Stdlib\AbstractOptions;
+
+use function iterator_to_array;
+
 final class PhpSerializeOptions extends AdapterOptions
 {
     /**
@@ -15,23 +19,80 @@ final class PhpSerializeOptions extends AdapterOptions
      * - `true` if all classes should be allowed (behavior pre-PHP 7.0)
      * - `false` if no classes should be allowed
      *
+     * @deprecated Since 3.3.0. Use $allowedClasses instead
+     *
      * @var class-string[]|bool
      */
     protected bool|array $unserializeClassWhitelist = true;
 
     /**
-     * @param class-string[]|bool $unserializeClassWhitelist
+     * The list of allowed classes for unserialization (PHP 7.0+).
+     *
+     * @see https://www.php.net/unserialize
+     *
+     * Possible values:
+     *
+     * - `array` of class names that are allowed to be unserialized
+     * - `true` if all classes should be allowed (behavior pre-PHP 7.0)
+     * - `false` if no classes should be allowed
+     *
+     * @var list<class-string>|bool
      */
-    public function setUnserializeClassWhitelist(bool|array $unserializeClassWhitelist): void
+    protected bool|array $allowedClasses = true;
+
+    /**
+     * @param iterable<string, mixed>|AbstractOptions<mixed>|null $options
+     */
+    public function __construct(iterable|AbstractOptions|null $options = null)
     {
-        $this->unserializeClassWhitelist = $unserializeClassWhitelist;
+        $options = $options instanceof AbstractOptions
+            ? $options->toArray()
+            : iterator_to_array($options ?? []);
+
+        if (isset($options['unserialize_class_whitelist']) && ! isset($options['allowed_classes'])) {
+            $options['allowed_classes'] = $options['unserialize_class_whitelist'];
+        }
+
+        parent::__construct($options);
     }
 
     /**
-     * @return class-string[]|bool
+     * @deprecated Since 3.3.0. Use {@link setAllowedClasses()} instead
+     *
+     * @param list<class-string>|bool $unserializeClassWhitelist
+     */
+    public function setUnserializeClassWhitelist(bool|array $unserializeClassWhitelist): void
+    {
+        $this->allowedClasses = $unserializeClassWhitelist;
+    }
+
+    /**
+     * @deprecated Since 3.3.0. Use {@link getAllowedClasses()} instead
+     *
+     * @return list<class-string>|bool
      */
     public function getUnserializeClassWhitelist(): bool|array
     {
-        return $this->unserializeClassWhitelist;
+        return $this->allowedClasses;
+    }
+
+    /**
+     * @see https://www.php.net/unserialize
+     *
+     * @param list<class-string>|bool $allowedClasses
+     */
+    public function setAllowedClasses(bool|array $allowedClasses): void
+    {
+        $this->allowedClasses = $allowedClasses;
+    }
+
+    /**
+     * @see https://www.php.net/unserialize
+     *
+     * @return list<class-string>|bool
+     */
+    public function getAllowedClasses(): bool|array
+    {
+        return $this->allowedClasses;
     }
 }

--- a/test/Adapter/PhpSerializeOptionsTest.php
+++ b/test/Adapter/PhpSerializeOptionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Serializer\Adapter;
+
+use Laminas\Serializer\Adapter\PhpSerializeOptions;
+use PHPUnit\Framework\TestCase;
+
+final class PhpSerializeOptionsTest extends TestCase
+{
+    public function testSetGetOption(): void
+    {
+        $options = new PhpSerializeOptions([
+            'allowed_classes' => [self::class],
+        ]);
+
+        self::assertSame([self::class], $options->getAllowedClasses());
+
+        $options->setAllowedClasses(true);
+        self::assertTrue($options->getAllowedClasses());
+    }
+
+    public function testLegacyOptionIsAvailableUnderNewName(): void
+    {
+        $options = new PhpSerializeOptions([
+            'unserialize_class_whitelist' => [self::class],
+        ]);
+
+        self::assertSame([self::class], $options->getAllowedClasses());
+        self::assertSame([self::class], $options->getUnserializeClassWhitelist());
+    }
+}


### PR DESCRIPTION
Deprecates the option `unserialize_class_whitelist` in favour of `allowed_classes`