### PR TITLE
Remove deprecated option for the `PhpSerialize` adapter

### DIFF
--- a/docs/book/v4/adapter.md
+++ b/docs/book/v4/adapter.md
@@ -18,9 +18,9 @@ functions, and is a good default adapter choice.
 
 Available options include:
 
-| Option                      | Data Type         | Default Value | Description                                                                                                                                        |
-|-----------------------------|-------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| unserialize_class_whitelist | `array` or `bool` | `true`        | The allowed classes for unserialize(), see [unserialize()](https://php.net/unserialize) for more information. Only available on PHP 7.0 or higher. |
+| Option          | Data Type         | Default Value | Description                                                                                                   |
+|-----------------|-------------------|---------------|---------------------------------------------------------------------------------------------------------------|
+| allowed_classes | `array` or `bool` | `true`        | The allowed classes for unserialize(), see [unserialize()](https://php.net/unserialize) for more information. |
 
 ## The IgBinary Adapter
 

--- a/docs/book/v4/migration/to-version-4.md
+++ b/docs/book/v4/migration/to-version-4.md
@@ -1,0 +1,10 @@
+# Migration to Version 4.0
+
+Upgrading `laminas-serializer` will require some code changes, depending on how the serializers were used.
+
+## Breaking Changes
+
+### Option name changes for PhpSerializer
+
+The deprecated option `unserialize_class_whitelist` has been renamed to `allowed_classes` and the setter and getter for the previous option name has been removed: `setUnserializeClassWhitelist()` and `getUnserializeClassWhitelist()` respectively.
+Replacement methods are named `setAllowedClasses()` and `getAllowedClasses()`.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,11 +16,6 @@
       <code><![CDATA[$options]]></code>
     </NonInvariantDocblockPropertyType>
   </file>
-  <file src="src/Adapter/PhpSerializeOptions.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setUnserializeClassWhitelist]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/AdapterPluginManagerFactory.php">
     <MixedArgument>
       <code><![CDATA[$config['serializers']]]></code>
@@ -39,10 +34,5 @@
     <UnusedParam>
       <code><![CDATA[$moduleManager]]></code>
     </UnusedParam>
-  </file>
-  <file src="test/Adapter/PhpSerializeOptionsTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getUnserializeClassWhitelist]]></code>
-    </DeprecatedMethod>
   </file>
 </files>

--- a/src/Adapter/PhpSerializeOptions.php
+++ b/src/Adapter/PhpSerializeOptions.php
@@ -4,27 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Serializer\Adapter;
 
-use Laminas\Stdlib\AbstractOptions;
-
-use function iterator_to_array;
-
 final class PhpSerializeOptions extends AdapterOptions
 {
-    /**
-     * The list of allowed classes for unserialization (PHP 7.0+).
-     *
-     * Possible values:
-     *
-     * - `array` of class names that are allowed to be unserialized
-     * - `true` if all classes should be allowed (behavior pre-PHP 7.0)
-     * - `false` if no classes should be allowed
-     *
-     * @deprecated Since 3.3.0. Use $allowedClasses instead
-     *
-     * @var class-string[]|bool
-     */
-    protected bool|array $unserializeClassWhitelist = true;
-
     /**
      * The list of allowed classes for unserialization (PHP 7.0+).
      *
@@ -39,42 +20,6 @@ final class PhpSerializeOptions extends AdapterOptions
      * @var list<class-string>|bool
      */
     protected bool|array $allowedClasses = true;
-
-    /**
-     * @param iterable<string, mixed>|AbstractOptions<mixed>|null $options
-     */
-    public function __construct(iterable|AbstractOptions|null $options = null)
-    {
-        $options = $options instanceof AbstractOptions
-            ? $options->toArray()
-            : iterator_to_array($options ?? []);
-
-        if (isset($options['unserialize_class_whitelist']) && ! isset($options['allowed_classes'])) {
-            $options['allowed_classes'] = $options['unserialize_class_whitelist'];
-        }
-
-        parent::__construct($options);
-    }
-
-    /**
-     * @deprecated Since 3.3.0. Use {@link setAllowedClasses()} instead
-     *
-     * @param list<class-string>|bool $unserializeClassWhitelist
-     */
-    public function setUnserializeClassWhitelist(bool|array $unserializeClassWhitelist): void
-    {
-        $this->allowedClasses = $unserializeClassWhitelist;
-    }
-
-    /**
-     * @deprecated Since 3.3.0. Use {@link getAllowedClasses()} instead
-     *
-     * @return list<class-string>|bool
-     */
-    public function getUnserializeClassWhitelist(): bool|array
-    {
-        return $this->allowedClasses;
-    }
 
     /**
      * @see https://www.php.net/unserialize

--- a/test/Adapter/PhpSerializeOptionsTest.php
+++ b/test/Adapter/PhpSerializeOptionsTest.php
@@ -20,14 +20,4 @@ final class PhpSerializeOptionsTest extends TestCase
         $options->setAllowedClasses(true);
         self::assertTrue($options->getAllowedClasses());
     }
-
-    public function testLegacyOptionIsAvailableUnderNewName(): void
-    {
-        $options = new PhpSerializeOptions([
-            'unserialize_class_whitelist' => [self::class],
-        ]);
-
-        self::assertSame([self::class], $options->getAllowedClasses());
-        self::assertSame([self::class], $options->getUnserializeClassWhitelist());
-    }
 }


### PR DESCRIPTION
Removes the `unserialize_class_whitelist` in favour of `allowed_classes`